### PR TITLE
Git - Fix - syntax error in workflow

### DIFF
--- a/.github/workflows/publish_app.yml
+++ b/.github/workflows/publish_app.yml
@@ -24,12 +24,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7.0.x
-
       - name: Build
         shell: bash
         run: |
@@ -49,7 +47,6 @@ jobs:
 
           # Delete output directory
           rm -r "$release_name"
-
       - name: Publish
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/publish_app.yml
+++ b/.github/workflows/publish_app.yml
@@ -1,4 +1,4 @@
-name: .NET Publish App
+name: .NET Publish CLI App
 permissions:
   contents: write
 on:
@@ -30,7 +30,7 @@ jobs:
         with:
           dotnet-version: 7.0.x
 
-      - name: Build Chirp CLI
+      - name: Build
         shell: bash
         run: |
           # Define some variables for things we need
@@ -50,7 +50,7 @@ jobs:
           # Delete output directory
           rm -r "$release_name"
 
-      - name: Publish Chirp CLI
+      - name: Publish
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:


### PR DESCRIPTION
Workflow to publish app not working due to syntax error. This PR fixes it.