### PR TITLE
Fix - Fixed fallback filePath to be in current directory

### DIFF
--- a/src/Chirp.CSVDB/CsvDatabase.cs
+++ b/src/Chirp.CSVDB/CsvDatabase.cs
@@ -14,6 +14,7 @@ namespace Chirp.CSVDB
             _filePath = filePath;
             if (!File.Exists(filePath))
             {
+                _filePath = "./chirp_db.csv";
                 File.WriteAllText(filePath, "Author,Message,Timestamp");
             }
         }


### PR DESCRIPTION
We were getting a `DirectoryNotFoundException` in deployment. This PR fixes it.